### PR TITLE
Dynamic column loading for YALV

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ D-YALV is a fork of YALV! that supports custom columns & data. During your appli
     <log4j:data name="executionId" value="7FF2DFF98DA8314C8CF428A46FBE4555" />
 
   </log4j:properties>
-<log4j:locationInfo class="PISON.NetworkSnapshot.Service.Preparation.CellPmLoader+&lt;LoadKpis&gt;d__2" method="MoveNext" file="C:\BuildAgent\work\d6ca94c1f82fb28a\PISON.NetworkSnapshot.Service\Preparation\CellPmLoader.cs" line="43" />
+<log4j:locationInfo class="..." method="MoveNext" file="..." line="43" />
 </log4j:event>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,8 @@
-# YALV! - Yet Another Log4Net Viewer
+# D-YALV! - (Dynamic) Yet Another Log4Net Viewer
 
 YALV! is a log file viewer for Log4Net with handy features like log merging, filtering, open most recently used files, items sorting and so on. It is easy to use, it requires no configuration, it has intuitive and user-friendly interface and available in several languages. It is a WPF Application based on .NET Framework 4.0 and written in C# language.
 
-![Screenshot](/doc/images/YALV-Win.png?raw=true "YALV Main Window") 
-[More Screenshots](https://github.com/LukePet/YALV/wiki/Screenshots)
-
-## Main features
-* Log files merging into one list
-* Dynamic log events filtering
-* Dynamic show/hide log events by log level
-* Favorites log folders list
-* Open most recently used files
-* Sort and reorder columns
-* Copy log event data to clipboard
-* Open files by dragging them to the main window
-
-## Localizations
-* English
-* French
-* German
-* Italian
-* Russian
-* Japanese
-* Chinese
-* Greek
-
-## Configuration
-YALV itself does not require any setup, but log4net must be setup in your application to write XML content in XmlLayoutSchemaLog4j layout to log files. [Read more...](https://github.com/LukePet/YALV/wiki)
+D-YALV is a fork of YALV! that supports custom columns & data. During your applications execution, just log your custom data as a <log:data> element, and D-YALV will show them dynamically. 
 
 ## Usage
-Download latest binaries, unzip and launch YALV.exe. That's all!
-YALV GUI language follows your Windows culture automatically, but you can override this behavior.
+Use it just like how you would use YALV!.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ D-YALV is a fork of YALV! that supports custom columns & data. During your appli
     <log4j:data name="log4net:HostName" value="system" />
     
     <!-- Custom columns, added by you -->
-    <log4j:data name="executionPlanId" value="410" />
-    <log4j:data name="executionId" value="7FF2DFF98DA8314C8CF428A46FBE4555" />
+    <log4j:data name="userId" value="410" />
+    <log4j:data name="locationGuid" value="7FF2DFF98DA8314C8CF428A46FBE4555" />
 
   </log4j:properties>
 <log4j:locationInfo class="..." method="MoveNext" file="..." line="43" />

--- a/README.md
+++ b/README.md
@@ -2,7 +2,29 @@
 
 YALV! is a log file viewer for Log4Net with handy features like log merging, filtering, open most recently used files, items sorting and so on. It is easy to use, it requires no configuration, it has intuitive and user-friendly interface and available in several languages. It is a WPF Application based on .NET Framework 4.0 and written in C# language.
 
-D-YALV is a fork of YALV! that supports custom columns & data. During your applications execution, just log your custom data as a <log:data> element, and D-YALV will show them dynamically. 
+D-YALV is a fork of YALV! that supports custom columns & data. During your applications execution, just log your custom data as a <log:data> element, like so:
+
+```xml
+<log4j:event logger="LoggingService" timestamp="1471208402881" level="DEBUG" thread="30">
+  <log4j:message>Testing logs..</log4j:message>
+  <log4j:properties>
+    <!-- Default log4net columns -->
+    <log4j:data name="log4jmachinename" value="user-machine" />
+    <log4j:data name="log4net:Identity" value="SYSTEM" />
+    <log4j:data name="log4net:UserName" value="SYSTEM\USER" />
+    <log4j:data name="log4japp" value="LoggingService.exe" />
+    <log4j:data name="log4net:HostName" value="system" />
+    
+    <!-- Custom columns, added by you -->
+    <log4j:data name="executionPlanId" value="410" />
+    <log4j:data name="executionId" value="7FF2DFF98DA8314C8CF428A46FBE4555" />
+
+  </log4j:properties>
+<log4j:locationInfo class="PISON.NetworkSnapshot.Service.Preparation.CellPmLoader+&lt;LoadKpis&gt;d__2" method="MoveNext" file="C:\BuildAgent\work\d6ca94c1f82fb28a\PISON.NetworkSnapshot.Service\Preparation\CellPmLoader.cs" line="43" />
+</log4j:event>
+```
+
+and D-YALV will show them just like a default log4net column. 
 
 ## Usage
 Use it just like how you would use YALV!.

--- a/src/YALV.Core/Domain/LogItem.cs
+++ b/src/YALV.Core/Domain/LogItem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace YALV.Core.Domain
 {
@@ -23,6 +24,8 @@ namespace YALV.Core.Domain
         public string File { get; set; }
         public string Line { get; set; }
         public string Uncategorized { get; set; }
+
+	    public Dictionary<string, string> CustomFields { get; set; } = new Dictionary<string, string>();
 
         /// <summary>
         /// LevelIndex

--- a/src/YALV.Core/Providers/XmlEntriesProvider.cs
+++ b/src/YALV.Core/Providers/XmlEntriesProvider.cs
@@ -71,6 +71,14 @@ namespace YALV.Core.Providers
                                                     case ("log4net:HostName"):
                                                         entry.HostName = xmlTextReader.GetAttribute("value");
                                                         break;
+													default:
+		                                                var name = xmlTextReader.GetAttribute("name");
+		                                                if (!name.StartsWith("log4net:"))
+		                                                {
+															var val = xmlTextReader.GetAttribute("value");
+															entry.CustomFields.Add(name, val);
+														}
+														break;
                                                 }
                                                 break;
                                             case ("log4j:throwable"):
@@ -97,6 +105,7 @@ namespace YALV.Core.Providers
                     }
                 }
             }
+
         }
 
         private static bool filterByParameters(LogItem entry, FilterParams parameters)

--- a/src/YALV.Core/YALV.Core.csproj
+++ b/src/YALV.Core/YALV.Core.csproj
@@ -29,6 +29,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/YALV.sln
+++ b/src/YALV.sln
@@ -10,9 +10,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YALV.Core", "YALV.Core\YALV.Core.csproj", "{D8EFA045-5482-4BBA-A1BF-28667D5F4635}"
 EndProject
 Global
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x86 = Debug|x86

--- a/src/YALV.sln
+++ b/src/YALV.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YALV", "YALV\YALV.csproj", "{D9109556-5B27-4FF2-AB53-837DF91A5466}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YALV.Samples", "YALV.Samples\YALV.Samples.csproj", "{5276151E-F717-4893-9A09-C9DD3CE65F83}"
@@ -8,6 +10,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YALV.Core", "YALV.Core\YALV.Core.csproj", "{D8EFA045-5482-4BBA-A1BF-28667D5F4635}"
 EndProject
 Global
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x86 = Debug|x86

--- a/src/YALV/Common/FilteredGridManager.cs
+++ b/src/YALV/Common/FilteredGridManager.cs
@@ -51,6 +51,7 @@ namespace YALV.Common
             if (columns != null)
             {
 				_dg.Columns.Clear();
+				_txtSearchPanel.Children.Clear();
                 foreach (ColumnItem item in columns)
                 {
                     DataGridTextColumn col = new DataGridTextColumn();

--- a/src/YALV/Common/FilteredGridManager.cs
+++ b/src/YALV/Common/FilteredGridManager.cs
@@ -103,13 +103,13 @@ namespace YALV.Common
                         Style txtStyle = Application.Current.FindResource("RoundWatermarkTextBox") as Style;
                         if (txtStyle != null)
                             txt.Style = txtStyle;
-                        txt.Name = getTextBoxName(item.Field);
+                        txt.Name = getTextBoxName(item.Field.Replace(" ", ""));
                         txt.ToolTip = String.Format(Resources.FilteredGridManager_BuildDataGrid_FilterTextBox_Tooltip, item.Header);
                         txt.Tag = txt.ToolTip.ToString().ToLower();
                         txt.Text = string.Empty;
                         txt.AcceptsReturn = false;
                         txt.SetBinding(TextBox.WidthProperty, widthBind);
-                        _filterPropertyList.Add(item.Field);
+                        _filterPropertyList.Add(item.Field.Replace(" ",""));
                         if (_keyUpEvent != null)
                             txt.KeyUp += _keyUpEvent;
 

--- a/src/YALV/Common/FilteredGridManager.cs
+++ b/src/YALV/Common/FilteredGridManager.cs
@@ -1,14 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
-using System.Windows.Input;
+using System.Windows.Forms;
 using YALV.Common.Converters;
 using YALV.Core.Domain;
 using YALV.Properties;
+using Application = System.Windows.Application;
+using Binding = System.Windows.Data.Binding;
+using DataGrid = System.Windows.Controls.DataGrid;
+using KeyEventHandler = System.Windows.Input.KeyEventHandler;
+using Panel = System.Windows.Controls.Panel;
+using TextBox = System.Windows.Controls.TextBox;
 
 namespace YALV.Common
 {
@@ -31,7 +38,7 @@ namespace YALV.Common
 
         #region Public Methods
 
-        public void BuildDataGrid(IList<ColumnItem> columns)
+        public void BuildDataGrid(IList<ColumnItem> columns, List<ColumnItem> newColumns = null)
         {
             if (_dg == null)
                 return;
@@ -43,10 +50,12 @@ namespace YALV.Common
 
             if (columns != null)
             {
+				_dg.Columns.Clear();
                 foreach (ColumnItem item in columns)
                 {
                     DataGridTextColumn col = new DataGridTextColumn();
-                    col.Header = item.Header;
+
+					col.Header = item.Header;
                     if (item.Alignment == CellAlignment.CENTER && _centerCellStyle != null)
                         col.CellStyle = _centerCellStyle;
                     if (item.MinWidth != null)
@@ -54,8 +63,24 @@ namespace YALV.Common
                     if (item.Width != null)
                         col.Width = item.Width.Value;
 
-                    Binding bind = new Binding(item.Field) { Mode = BindingMode.OneWay };
-                    bind.ConverterCulture = System.Globalization.CultureInfo.GetCultureInfo(Properties.Resources.CultureName);
+	                Binding bind;
+	                if (newColumns != null && newColumns.Count > 0)
+	                {
+		                if (newColumns.Contains(item))
+		                {
+			                bind = new Binding(string.Format("CustomFields[{0}]", item.Field)) {Mode = BindingMode.OneWay};
+		                }
+		                else
+		                {
+							bind = new Binding(item.Field) { Mode = BindingMode.OneWay };
+						}
+					}
+	                else
+	                {
+						bind = new Binding(item.Field) { Mode = BindingMode.OneWay };
+					}
+
+					bind.ConverterCulture = System.Globalization.CultureInfo.GetCultureInfo(Properties.Resources.CultureName);
                     if (!String.IsNullOrWhiteSpace(item.StringFormat))
                         bind.StringFormat = item.StringFormat;
                     col.Binding = bind;

--- a/src/YALV/Common/FilteredGridManagerBase.cs
+++ b/src/YALV/Common/FilteredGridManagerBase.cs
@@ -202,8 +202,18 @@ namespace YALV.Common
             }
             catch
             {
-                val = null;
-            }
+	            try
+	            {
+		            var custom = item.GetType().GetProperty("CustomFields");
+					var inf = custom.GetValue(item, null);
+
+		            val = ((Dictionary<string, string>) inf)[prop];
+	            }
+				catch 
+	            {
+					val = null;
+				}
+			}
             return val;
         }
 

--- a/src/YALV/Common/FilteredGridManagerBase.cs
+++ b/src/YALV/Common/FilteredGridManagerBase.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
@@ -20,7 +21,6 @@ namespace YALV.Common
             _txtSearchPanel = txtSearchPanel;
             _keyUpEvent = keyUpEvent;
             _filterPropertyList = new List<string>();
-            _txtCache = new Hashtable();
             IsFilteringEnabled = true;
         }
 
@@ -138,15 +138,9 @@ namespace YALV.Common
                     foreach (string prop in _filterPropertyList)
                     {
                         TextBox txt = null;
-                        if (_txtCache.ContainsKey(prop))
-                            txt = _txtCache[prop] as TextBox;
-                        else
-                        {
-                            txt = _txtSearchPanel.FindName(getTextBoxName(prop)) as TextBox;
-                            _txtCache[prop] = txt;
-                        }
+						txt = _txtSearchPanel.FindName(getTextBoxName(prop)) as TextBox;
 
-                        res = false;
+						res = false;
                         if (txt == null)
                             res = true;
                         else
@@ -196,25 +190,30 @@ namespace YALV.Common
         protected object getItemValue(object item, string prop)
         {
             object val = null;
-            try
-            {
-                val = item.GetType().GetProperty(prop).GetValue(item, null);
-            }
-            catch
-            {
-	            try
-	            {
-		            var custom = item.GetType().GetProperty("CustomFields");
+
+	        var type = item.GetType();
+	        var properties = type.GetProperties();
+
+			var isBase = properties.Any(p => p.Name == prop);
+			if (isBase)
+			{
+				val = type.GetProperty(prop).GetValue(item, null);
+			}
+			else
+			{
+				try
+				{
+					var custom = type.GetProperty("CustomFields");
 					var inf = custom.GetValue(item, null);
 
-		            val = ((Dictionary<string, string>) inf)[prop];
-	            }
-				catch 
-	            {
+					val = ((Dictionary<string, string>)inf)[prop];
+				}
+				catch (Exception)
+				{
 					val = null;
 				}
 			}
-            return val;
+			return val;
         }
 
         #endregion

--- a/src/YALV/MainWindow.xaml.cs
+++ b/src/YALV/MainWindow.xaml.cs
@@ -121,8 +121,8 @@ namespace YALV
                     case MainWindowVM.NOTIFY_ScrollIntoView:
                         if (dgItems != null && dgItems.SelectedItem != null)
                         {
-                            //dgItems.UpdateLayout();
-                            //dgItems.ScrollIntoView(dgItems.SelectedItem);
+                            dgItems.UpdateLayout();
+                            dgItems.ScrollIntoView(dgItems.SelectedItem);
                         }
                         break;
                     default:

--- a/src/YALV/MainWindow.xaml.cs
+++ b/src/YALV/MainWindow.xaml.cs
@@ -19,6 +19,7 @@ using System.Configuration;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
 using YALV.Common;
 using YALV.Common.Interfaces;
@@ -48,6 +49,9 @@ namespace YALV
             _vm.RecentFileList = mainMenu.RecentFileList;
             _vm.RefreshUI = OnRefreshUI;
             this.DataContext = _vm;
+
+	        dgItems.EnableColumnVirtualization = true;
+	        dgItems.EnableRowVirtualization = true;
 
             //Assign events
             dgItems.SelectionChanged += dgItems_SelectionChanged;
@@ -111,13 +115,14 @@ namespace YALV
         {
             try
             {
+				
                 switch (eventName)
                 {
                     case MainWindowVM.NOTIFY_ScrollIntoView:
                         if (dgItems != null && dgItems.SelectedItem != null)
                         {
-                            dgItems.UpdateLayout();
-                            dgItems.ScrollIntoView(dgItems.SelectedItem);
+                            //dgItems.UpdateLayout();
+                            //dgItems.ScrollIntoView(dgItems.SelectedItem);
                         }
                         break;
                     default:

--- a/src/YALV/ViewModel/MainWindowVM.cs
+++ b/src/YALV/ViewModel/MainWindowVM.cs
@@ -1330,8 +1330,12 @@ namespace YALV.ViewModel
                         SelectedLogItem = lastItem != null ? lastItem : Items[Items.Count - 1];
                     }
 
-	                var logItem = (List<LogItem>)((object[])e.Result)[0];
-					ReInitDataGridWithNewColumns(logItem[0].CustomFields);
+	                var result = (List<LogItem>)((object[])e.Result)[0];
+	                var maxCustomFields = result.Max(c => c.CustomFields.Count);
+
+	                var logItem = result.First(r => r.CustomFields.Count == maxCustomFields);
+					
+					ReInitDataGridWithNewColumns(logItem.CustomFields);
                 }
             }
             IsLoading = false;
@@ -1348,7 +1352,6 @@ namespace YALV.ViewModel
 
         public void InitDataGrid()
         {
-	        return;
             if (GridManager != null)
             {
 	            IList<ColumnItem> dgColumns = GetDefaultColumns();

--- a/src/YALV/ViewModel/MainWindowVM.cs
+++ b/src/YALV/ViewModel/MainWindowVM.cs
@@ -1329,6 +1329,9 @@ namespace YALV.ViewModel
 
                         SelectedLogItem = lastItem != null ? lastItem : Items[Items.Count - 1];
                     }
+
+	                var logItem = (List<LogItem>)((object[])e.Result)[0];
+					ReInitDataGridWithNewColumns(logItem[0].CustomFields);
                 }
             }
             IsLoading = false;
@@ -1345,31 +1348,58 @@ namespace YALV.ViewModel
 
         public void InitDataGrid()
         {
+	        return;
             if (GridManager != null)
             {
-                IList<ColumnItem> dgColumns = new List<ColumnItem>()
-                {
-                    new ColumnItem("Id", 37, null, CellAlignment.CENTER,string.Empty){Header = Resources.MainWindowVM_InitDataGrid_IdColumn_Header},
-                    new ColumnItem("TimeStamp", 120, null, CellAlignment.CENTER, GlobalHelper.DisplayDateTimeFormat){Header = Resources.MainWindowVM_InitDataGrid_TimeStampColumn_Header},
-                    new ColumnItem("Level", null, 50, CellAlignment.CENTER){Header = Resources.MainWindowVM_InitDataGrid_LevelColumn_Header},
-                    new ColumnItem("Message", null, 300){Header = Resources.MainWindowVM_InitDataGrid_MessageColumn_Header},
-                    new ColumnItem("Logger", 150, null){Header = Resources.MainWindowVM_InitDataGrid_LoggerColumn_Header},
-                    new ColumnItem("MachineName", 110, null, CellAlignment.CENTER){Header = Resources.MainWindowVM_InitDataGrid_MachineNameColumn_Header},
-                    new ColumnItem("HostName", 110, null, CellAlignment.CENTER){Header = Resources.MainWindowVM_InitDataGrid_HostNameColumn_Header},
-                    new ColumnItem("UserName", 110, null, CellAlignment.CENTER){Header = Resources.MainWindowVM_InitDataGrid_UserNameColumn_Header},
-                    new ColumnItem("App", 150, null){Header = Resources.MainWindowVM_InitDataGrid_AppColumn_Header},
-                    new ColumnItem("Thread", 44, null, CellAlignment.CENTER){Header = Resources.MainWindowVM_InitDataGrid_ThreadColumn_Header},
-                    new ColumnItem("Class", null, 300){Header = Resources.MainWindowVM_InitDataGrid_ClassColumn_Header},
-                    new ColumnItem("Method", 200, null){Header = Resources.MainWindowVM_InitDataGrid_MethodColumn_Header}
-                    //new ColumnItem("Delta", 60, null, CellAlignment.CENTER, null, "Δ"),
-                    //new ColumnItem("Path", 50)
-                };
+	            IList<ColumnItem> dgColumns = GetDefaultColumns();
                 GridManager.BuildDataGrid(dgColumns);
                 GridManager.AssignSource(new Binding(MainWindowVM.PROP_Items) { Source = this, Mode = BindingMode.OneWay });
                 GridManager.OnBeforeCheckFilter = levelCheckFilter;
             }
         }
 
+	    private List<ColumnItem> GetDefaultColumns()
+		{
+			return new List<ColumnItem>()
+				{
+					new ColumnItem("Id", 37, null, CellAlignment.CENTER,string.Empty){Header = Resources.MainWindowVM_InitDataGrid_IdColumn_Header},
+					new ColumnItem("TimeStamp", 120, null, CellAlignment.CENTER, GlobalHelper.DisplayDateTimeFormat){Header = Resources.MainWindowVM_InitDataGrid_TimeStampColumn_Header},
+					new ColumnItem("Level", null, 50, CellAlignment.CENTER){Header = Resources.MainWindowVM_InitDataGrid_LevelColumn_Header},
+					new ColumnItem("Message", null, 300){Header = Resources.MainWindowVM_InitDataGrid_MessageColumn_Header},
+					new ColumnItem("Logger", 150, null){Header = Resources.MainWindowVM_InitDataGrid_LoggerColumn_Header},
+					new ColumnItem("MachineName", 110, null, CellAlignment.CENTER){Header = Resources.MainWindowVM_InitDataGrid_MachineNameColumn_Header},
+					new ColumnItem("HostName", 110, null, CellAlignment.CENTER){Header = Resources.MainWindowVM_InitDataGrid_HostNameColumn_Header},
+					new ColumnItem("UserName", 110, null, CellAlignment.CENTER){Header = Resources.MainWindowVM_InitDataGrid_UserNameColumn_Header},
+					new ColumnItem("App", 150, null){Header = Resources.MainWindowVM_InitDataGrid_AppColumn_Header},
+					new ColumnItem("Thread", 44, null, CellAlignment.CENTER){Header = Resources.MainWindowVM_InitDataGrid_ThreadColumn_Header},
+					new ColumnItem("Class", null, 300){Header = Resources.MainWindowVM_InitDataGrid_ClassColumn_Header},
+					new ColumnItem("Method", 200, null){Header = Resources.MainWindowVM_InitDataGrid_MethodColumn_Header}
+                };
+		}
+
+
+		public void ReInitDataGridWithNewColumns(Dictionary<string, string> customFields)
+        {
+            if (GridManager != null)
+            {
+	            var dgColumns = GetDefaultColumns();
+
+	            var newColumns = new List<ColumnItem>();
+	            foreach (var field in customFields)
+				{
+					var column = new ColumnItem(field.Key, null, 200)
+					{
+						Header = field.Key
+					};
+					newColumns.Add(column);
+					dgColumns.Add(column);
+				}
+
+				GridManager.BuildDataGrid(dgColumns, newColumns);
+                GridManager.AssignSource(new Binding(MainWindowVM.PROP_Items) { Source = this, Mode = BindingMode.OneWay });
+                GridManager.OnBeforeCheckFilter = levelCheckFilter;
+            }
+        }
         public void RefreshView()
         {
             if (GridManager != null)

--- a/src/YALV/ViewModel/MainWindowVM.cs
+++ b/src/YALV/ViewModel/MainWindowVM.cs
@@ -1330,14 +1330,18 @@ namespace YALV.ViewModel
                         SelectedLogItem = lastItem != null ? lastItem : Items[Items.Count - 1];
                     }
 
-	                var result = (List<LogItem>)((object[])e.Result)[0];
-	                var maxCustomFields = result.Max(c => c.CustomFields.Count);
+					var result = (List<LogItem>)((object[])e.Result)[0];
+					if (result.Count > 0)
+					{
+						var maxCustomFields = result.Max(c => c.CustomFields.Count);
 
-	                var logItem = result.First(r => r.CustomFields.Count == maxCustomFields);
-					
-					ReInitDataGridWithNewColumns(logItem.CustomFields);
-                }
-            }
+						var logItem = result.First(r => r.CustomFields.Count == maxCustomFields);
+
+						ReInitDataGridWithNewColumns(logItem.CustomFields);
+					}
+
+				}
+			}
             IsLoading = false;
         }
 

--- a/src/YALV/YALV.csproj
+++ b/src/YALV/YALV.csproj
@@ -68,6 +68,7 @@
     <CodeAnalysisRuleDirectories>;c:\Program Files (x86)\Microsoft Visual Studio 10.0\Team Tools\Static Analysis Tools\FxCop\\Rules</CodeAnalysisRuleDirectories>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
     <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup />
   <PropertyGroup>


### PR DESCRIPTION
Hello,

We use YALV! extensively in our work, and we love it- but the one feature we think it lacks is the ability to display custom columns added in the log file, not just the default ones (like TimeStamp, Level etc). 

What we do is, we add custom data as a log4j:data element, then this fork of YALV! loads the column dynamically & displays it. This is very helpful as it enables you to practically log anything you want in a separate column, instead of logging everything in the message column.  For more details, please check the README.

Thank you very much for YALV!.
