### PR TITLE
Feature: column settings

### DIFF
--- a/src/YALV.Core/Constants.cs
+++ b/src/YALV.Core/Constants.cs
@@ -13,6 +13,6 @@ namespace YALV.Core
 
         public static string FOLDERS_FILE_PATH = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "YALVFolders.xml");
 
-        
+        public static string SETTINGS_FILE_PATH = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "YALVSettings.xml");
     }
 }

--- a/src/YALV.Core/DataService.cs
+++ b/src/YALV.Core/DataService.cs
@@ -131,6 +131,9 @@ namespace YALV.Core
                     var widthAttribute = element.Attribute("width");
                     if (widthAttribute != null) columnRenderSettings.Width = int.Parse(widthAttribute.Value);
 
+                    var visibleAttribute = element.Attribute("visible");
+                    if (visibleAttribute != null) columnRenderSettings.Visible = bool.Parse(visibleAttribute.Value);
+
                     result.Add(columnRenderSettings);
                 }
                 return result;
@@ -164,7 +167,8 @@ namespace YALV.Core
                                      select new XElement("column",
                                          new XAttribute("id", columnSettings.Id),
                                          new XAttribute("displayIndex", columnSettings.DisplayIndex),
-                                         new XAttribute("width", columnSettings.Width));
+                                         new XAttribute("width", columnSettings.Width),
+                                         new XAttribute("visible", columnSettings.Visible));
                 columnsElement.ReplaceAll(columnElements);
                 xml.Save(path);
             }

--- a/src/YALV.Core/DataService.cs
+++ b/src/YALV.Core/DataService.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Xml;
+using System.Xml.Linq;
 using YALV.Core.Domain;
 using YALV.Core.Providers;
 
@@ -33,7 +35,7 @@ namespace YALV.Core
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Trace.TraceError("Error saving Favorites list [{0}]:\r\n{1}\r\n{2}",path,ex.Message,ex.StackTrace);
+                Trace.TraceError("Error saving Favorites list [{0}]:\r\n{1}\r\n{2}", path, ex.Message, ex.StackTrace);
                 throw;
             }
             finally
@@ -43,7 +45,7 @@ namespace YALV.Core
                 if (fileStream != null)
                     fileStream.Close();
             }
-           
+
         }
 
         public static IList<PathItem> ParseFolderFile(string path)
@@ -80,7 +82,7 @@ namespace YALV.Core
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Trace.TraceError("Error parsing Favorites list [{0}]:\r\n{1}\r\n{2}", path, ex.Message, ex.StackTrace);
+                Trace.TraceError("Error parsing Favorites list [{0}]:\r\n{1}\r\n{2}", path, ex.Message, ex.StackTrace);
                 throw;
             }
             finally
@@ -103,7 +105,72 @@ namespace YALV.Core
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Trace.TraceError("Error parsing log file [{0}]:\r\n{1}\r\n{2}", path, ex.Message, ex.StackTrace);
+                Trace.TraceError("Error parsing log file [{0}]:\r\n{1}\r\n{2}", path, ex.Message, ex.StackTrace);
+                throw;
+            }
+        }
+
+        public static IList<ColumnRenderSettings> ParseSettings(string path)
+        {
+            if (!File.Exists(path))
+                return null;
+
+            try
+            {
+                var result = new List<ColumnRenderSettings>();
+
+                var xml = XDocument.Load(path);
+                foreach (var element in xml.Descendants("column"))
+                {
+                    var columnRenderSettings = new ColumnRenderSettings();
+                    columnRenderSettings.Id = element.Attribute("id").Value; // must have ID
+
+                    var displayIndexAttribute = element.Attribute("displayIndex");
+                    if (displayIndexAttribute != null) columnRenderSettings.DisplayIndex = int.Parse(displayIndexAttribute.Value);
+
+                    var widthAttribute = element.Attribute("width");
+                    if (widthAttribute != null) columnRenderSettings.Width = int.Parse(widthAttribute.Value);
+
+                    result.Add(columnRenderSettings);
+                }
+                return result;
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceError("Error parsing column settings from file {0}:\r\n{1}", path, ex);
+                throw;
+            }
+        }
+
+        public static void SaveSettings(IList<ColumnRenderSettings> columnRenderSettingsCollection, string path)
+        {
+            try
+            {
+                var xml = File.Exists(path) ? XDocument.Load(path) : new XDocument();
+
+                var columnsElement = xml.Descendants("columns").SingleOrDefault();
+                if (columnsElement == null)
+                {
+                    if (xml.Root == null)
+                    {
+                        var root = new XElement("settings");
+                        xml.Add(root);
+                    }
+                    columnsElement = new XElement("columns");
+                    xml.Root.Add(columnsElement);
+                }
+
+                var columnElements = from columnSettings in columnRenderSettingsCollection
+                                     select new XElement("column",
+                                         new XAttribute("id", columnSettings.Id),
+                                         new XAttribute("displayIndex", columnSettings.DisplayIndex),
+                                         new XAttribute("width", columnSettings.Width));
+                columnsElement.ReplaceAll(columnElements);
+                xml.Save(path);
+            }
+            catch (Exception ex)
+            {
+                Trace.TraceError("Error saving column settings in file {0}:\r\n{1}", path, ex);
                 throw;
             }
         }

--- a/src/YALV.Core/Domain/ColumnItem.cs
+++ b/src/YALV.Core/Domain/ColumnItem.cs
@@ -12,6 +12,8 @@ namespace YALV.Core.Domain
         public double? Width { get; set; }
         public CellAlignment Alignment { get; set; }
 
+        public int DisplayIndex { get; set; }
+
         public ColumnItem(string field, double? minWidth, double? width)
             : this(field, minWidth, width, CellAlignment.DEFAULT, string.Empty, field)
         {

--- a/src/YALV.Core/Domain/ColumnItem.cs
+++ b/src/YALV.Core/Domain/ColumnItem.cs
@@ -11,6 +11,7 @@ namespace YALV.Core.Domain
         public double? MinWidth { get; set; }
         public double? Width { get; set; }
         public CellAlignment Alignment { get; set; }
+        public bool Visible { get; set; } = true; // for backwards compatibility
 
         public int DisplayIndex { get; set; }
 

--- a/src/YALV.Core/Domain/ColumnItemComparer.cs
+++ b/src/YALV.Core/Domain/ColumnItemComparer.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace YALV.Core.Domain
+{
+    public class ColumnItemComparer : IComparer<ColumnItem>
+    {
+        public int Compare(ColumnItem x, ColumnItem y)
+        {
+            return x.DisplayIndex.CompareTo(y.DisplayIndex);
+        }
+    }
+}

--- a/src/YALV.Core/Domain/ColumnItemComparer.cs
+++ b/src/YALV.Core/Domain/ColumnItemComparer.cs
@@ -6,6 +6,18 @@ namespace YALV.Core.Domain
     {
         public int Compare(ColumnItem x, ColumnItem y)
         {
+            if (x.Field == y.Field)
+            {
+                return 0;
+            }
+            if (x.Visible && !y.Visible)
+            {
+                return -1;
+            }
+            if (!x.Visible && y.Visible)
+            {
+                return 1;
+            }
             return x.DisplayIndex.CompareTo(y.DisplayIndex);
         }
     }

--- a/src/YALV.Core/Domain/ColumnRenderSettings.cs
+++ b/src/YALV.Core/Domain/ColumnRenderSettings.cs
@@ -4,11 +4,12 @@ using System.Diagnostics;
 namespace YALV.Core.Domain
 {
     [Serializable]
-    [DebuggerDisplay("#{DisplayIndex} {Id,nq}, Width={Width}px")]
+    [DebuggerDisplay("#{DisplayIndex} {Id,nq}, Width={Width}px, Visible={Visible}")]
     public class ColumnRenderSettings
     {
         public string Id { get; set; }
         public int DisplayIndex { get; set; }
         public int Width { get; set; }
+        public bool Visible { get; set; }
     }
 }

--- a/src/YALV.Core/Domain/ColumnRenderSettings.cs
+++ b/src/YALV.Core/Domain/ColumnRenderSettings.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace YALV.Core.Domain
+{
+    [Serializable]
+    [DebuggerDisplay("#{DisplayIndex} {Id,nq}, Width={Width}px")]
+    public class ColumnRenderSettings
+    {
+        public string Id { get; set; }
+        public int DisplayIndex { get; set; }
+        public int Width { get; set; }
+    }
+}

--- a/src/YALV.Core/Domain/ColumnVisibilitySettings.cs
+++ b/src/YALV.Core/Domain/ColumnVisibilitySettings.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Reflection;
+
+namespace YALV.Core.Domain
+{
+    public class ColumnVisibilitySettings
+    {
+        public bool ShowId { get; set; }
+
+        public bool ShowTimeStamp { get; set; }
+
+        public bool ShowThread { get; set; }
+
+        public bool ShowLevel { get; set; }
+
+        public bool ShowLogger { get; set; }
+
+        public bool ShowMessage { get; set; }
+
+        public bool ShowApp { get; set; }
+
+        public bool ShowUserName { get; set; }
+
+        public bool ShowMachineName { get; set; }
+
+        public bool ShowHostName { get; set; }
+
+        public bool ShowClass { get; set; }
+
+        public bool ShowMethod { get; set; }
+
+        /// <summary>
+        /// Gets this class's property that matches the property of a <see cref="LogItem"/>.
+        /// </summary>
+        /// <param name="logItemPropertyName">The property of the log item.</param>
+        /// <returns>The matching property.</returns>
+        public static PropertyInfo GetPropertyByLogItemType(string logItemPropertyName)
+        {
+            var propertyName = "Show" + logItemPropertyName;
+            var property = typeof(ColumnVisibilitySettings).GetProperty(propertyName);
+            if (property == null) throw new MemberAccessException("Could not find property " + logItemPropertyName);
+            return property;
+        }
+    }
+}

--- a/src/YALV.Core/YALV.Core.csproj
+++ b/src/YALV.Core/YALV.Core.csproj
@@ -46,6 +46,8 @@
     <Compile Include="DataService.cs" />
     <Compile Include="Domain\BindableObject.cs" />
     <Compile Include="Domain\ColumnItem.cs" />
+    <Compile Include="Domain\ColumnItemComparer.cs" />
+    <Compile Include="Domain\ColumnRenderSettings.cs" />
     <Compile Include="Domain\DisposableObject.cs" />
     <Compile Include="Domain\EntriesProviderType.cs" />
     <Compile Include="Domain\FileItem.cs" />

--- a/src/YALV.Core/YALV.Core.csproj
+++ b/src/YALV.Core/YALV.Core.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Domain\ColumnItem.cs" />
     <Compile Include="Domain\ColumnItemComparer.cs" />
     <Compile Include="Domain\ColumnRenderSettings.cs" />
+    <Compile Include="Domain\ColumnVisibilitySettings.cs" />
     <Compile Include="Domain\DisposableObject.cs" />
     <Compile Include="Domain\EntriesProviderType.cs" />
     <Compile Include="Domain\FileItem.cs" />

--- a/src/YALV/Common/CommandReference.cs
+++ b/src/YALV/Common/CommandReference.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Input;
+
+namespace YALV.Common
+{
+    // https://sblanco.wordpress.com/2011/12/21/wpf-bind-contextmenu-command-from-datagrid-header/
+
+    /// <summary>
+    /// This class facilitates associating a key binding in XAML markup to  a command     
+    /// defined in a View Model by exposing a Command dependency property.      
+    /// The class derives from Freezable to work around a limitation in WPF when data-binding from XAML.      
+    /// </summary>      
+    public class CommandReference : Freezable, ICommand
+    {
+        public static readonly DependencyProperty CommandProperty = DependencyProperty.Register("Command", typeof(ICommand), typeof(CommandReference),
+            new PropertyMetadata(new PropertyChangedCallback(OnCommandChanged)));
+
+        public ICommand Command
+        {
+            get { return (ICommand)GetValue(CommandProperty); }
+            set { SetValue(CommandProperty, value); }
+        }
+
+
+        #region ICommand Members
+
+
+        public bool CanExecute(object parameter)
+        {
+            if (Command != null)
+                return Command.CanExecute(parameter);
+
+            return false;
+        }
+
+        public void Execute(object parameter)
+        {
+            Command.Execute(parameter);
+        }
+
+
+        public event EventHandler CanExecuteChanged;
+
+        private static void OnCommandChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            CommandReference commandReference = d as CommandReference;
+            ICommand oldCommand = e.OldValue as ICommand;
+            ICommand newCommand = e.NewValue as ICommand;
+
+            if (oldCommand != null)
+            {
+                oldCommand.CanExecuteChanged -= commandReference.CanExecuteChanged;
+            }
+
+            if (newCommand != null)
+            {
+                newCommand.CanExecuteChanged += commandReference.CanExecuteChanged;
+            }
+        }
+
+        #endregion
+
+        #region Freezable
+
+        protected override Freezable CreateInstanceCore()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+}

--- a/src/YALV/Common/FilteredGridManager.cs
+++ b/src/YALV/Common/FilteredGridManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -56,6 +57,7 @@ namespace YALV.Common
                         col.MinWidth = item.MinWidth.Value;
                     if (item.Width != null)
                         col.Width = item.Width.Value;
+                    col.Visibility = item.Visible ? Visibility.Visible : Visibility.Collapsed;
 
                     Binding bind = new Binding(item.Field) { Mode = BindingMode.OneWay };
                     bind.ConverterCulture = CultureInfo.GetCultureInfo(Resources.CultureName);
@@ -87,6 +89,15 @@ namespace YALV.Common
                         txt.Text = string.Empty;
                         txt.AcceptsReturn = false;
                         txt.SetBinding(TextBox.WidthProperty, widthBind);
+
+                        var visibilityBind = new Binding
+                        {
+                            Path = new PropertyPath(nameof(DataGridColumn.Visibility)),
+                            Source = col,
+                            Mode = BindingMode.OneWay
+                        };
+                        txt.SetBinding(TextBox.VisibilityProperty, visibilityBind);
+
                         _filterPropertyList.Add(item.Field);
                         if (_keyUpEvent != null)
                             txt.KeyUp += _keyUpEvent;
@@ -108,9 +119,41 @@ namespace YALV.Common
                 {
                     Id = (string)column.GetValue(ColumnIdProperty),
                     Width = (int)column.ActualWidth,
-                    DisplayIndex = column.DisplayIndex
+                    DisplayIndex = column.DisplayIndex,
+                    Visible = column.Visibility == Visibility.Visible
                 };
                 yield return columnSettings;
+            }
+        }
+
+        public ColumnVisibilitySettings GetColumnVisibilitySettings()
+        {
+            var settings = new ColumnVisibilitySettings();
+            var map = GetColumnVisibilityMap();
+            foreach (var item in map)
+            {
+                var show = item.Column.Visibility == Visibility.Visible;
+                item.ColumnVisibilitySettingsProperty.SetValue(settings, show, null);
+            }
+            return settings;
+        }
+
+        public void UpdateColumVisibilitySettings(ColumnVisibilitySettings settings)
+        {
+            var map = GetColumnVisibilityMap();
+            foreach (var tuple in map)
+            {
+                var shouldBeVisibile = (bool)tuple.ColumnVisibilitySettingsProperty.GetValue(settings, null);
+                var isVisible = tuple.Column.Visibility == Visibility.Visible;
+
+                if (shouldBeVisibile && !isVisible)
+                {
+                    tuple.Column.Visibility = Visibility.Visible;
+                }
+                else if (!shouldBeVisibile && isVisible)
+                {
+                    tuple.Column.Visibility = Visibility.Collapsed;
+                }
             }
         }
 
@@ -147,6 +190,29 @@ namespace YALV.Common
             element.RegisterName(controlName, control);
         }
 
+        private IEnumerable<ColumnVisibilityTuple> GetColumnVisibilityMap()
+        {
+            foreach (var column in _dg.Columns)
+            {
+                var columnId = (string)column.GetValue(ColumnIdProperty);
+                var tuple = new ColumnVisibilityTuple
+                {
+                    Column = column,
+                    ColumnVisibilitySettingsProperty = ColumnVisibilitySettings.GetPropertyByLogItemType(columnId)
+                };
+                yield return tuple;
+            }
+        }
+
         #endregion
+
+        /// <summary>
+        /// Maps a data grid column to a property of <see cref="ColumnVisibilitySettings"/>.
+        /// </summary>
+        private class ColumnVisibilityTuple
+        {
+            public DataGridColumn Column { get; set; }
+            public PropertyInfo ColumnVisibilitySettingsProperty { get; set; }
+        }
     }
 }

--- a/src/YALV/MainWindow.xaml
+++ b/src/YALV/MainWindow.xaml
@@ -926,7 +926,6 @@
                     <DataGrid
 						CanUserReorderColumns="True"
                         CellStyle="{StaticResource DefaultDataGridCellStyle}"
-                        ColumnHeaderStyle="{StaticResource DefaultDataGridHeaderStyle}"
                         IsSynchronizedWithCurrentItem="True"
 						Margin="0,1,0,0"
                         Name="dgItems"
@@ -952,7 +951,27 @@
                             <SolidColorBrush
                                 x:Key="{x:Static SystemColors.HighlightBrushKey}"
                                 Color="#19000000" />
+                            <local:CommandReference 
+                                x:Key="CommandSelectColumnsReference"
+                                Command="{Binding Path=CommandSelectColumns}" />
                         </DataGrid.Resources>
+
+                        <DataGrid.ColumnHeaderStyle>
+                            <Style 
+                                TargetType="DataGridColumnHeader" 
+                                BasedOn="{StaticResource DefaultDataGridHeaderStyle}">
+                                <Setter 
+                                    Property="ContextMenu">
+                                    <Setter.Value>
+                                        <ContextMenu>
+                                            <MenuItem
+                                                Header="{x:Static Properties:Resources.MainWindow_GridColumnHeaderContextMenu_SelectColumns}"
+                                                Command="{StaticResource CommandSelectColumnsReference}" />
+                                        </ContextMenu>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </DataGrid.ColumnHeaderStyle>
                     </DataGrid>
                 </DockPanel>
 

--- a/src/YALV/MainWindow.xaml.cs
+++ b/src/YALV/MainWindow.xaml.cs
@@ -62,6 +62,7 @@ namespace YALV
             {
                 dgItems.SelectionChanged -= dgItems_SelectionChanged;
                 txtItemId.KeyUp -= txtItemId_KeyUp;
+                _vm.SaveSettings();
                 _vm.Dispose();
             };
             this.Drop += (object sender, DragEventArgs e) =>

--- a/src/YALV/Properties/Resources.Designer.cs
+++ b/src/YALV/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace YALV.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class Resources {
@@ -91,7 +91,7 @@ namespace YALV.Properties {
         ///
         ///Log4Net config file must be setup with XmlLayoutSchemaLog4j layout; just need a few lines in your application config file to configure it to use this format (see examples on right).
         ///
-        ///It is a WPF Application based on .NET Framework 4.0 and writ [rest of string was truncated]&quot;;.
+        ///It is a WPF Application based on .NET Framework 4.0 and written with C#  [rest of string was truncated]&quot;;.
         /// </summary>
         public static string About_Description {
             get {
@@ -195,6 +195,177 @@ namespace YALV.Properties {
         public static string CircularProgressBar_CircularProgressBar_BusyText {
             get {
                 return ResourceManager.GetString("CircularProgressBar_CircularProgressBar_BusyText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Application.
+        /// </summary>
+        public static string ColumnSelection_ApplicationInfo_Application {
+            get {
+                return ResourceManager.GetString("ColumnSelection_ApplicationInfo_Application", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Host name.
+        /// </summary>
+        public static string ColumnSelection_ApplicationInfo_HostName {
+            get {
+                return ResourceManager.GetString("ColumnSelection_ApplicationInfo_HostName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Machine name.
+        /// </summary>
+        public static string ColumnSelection_ApplicationInfo_MachineName {
+            get {
+                return ResourceManager.GetString("ColumnSelection_ApplicationInfo_MachineName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to User name.
+        /// </summary>
+        public static string ColumnSelection_ApplicationInfo_UserName {
+            get {
+                return ResourceManager.GetString("ColumnSelection_ApplicationInfo_UserName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Application information.
+        /// </summary>
+        public static string ColumnSelection_ApplicationInfoGroup_Header {
+            get {
+                return ResourceManager.GetString("ColumnSelection_ApplicationInfoGroup_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Level.
+        /// </summary>
+        public static string ColumnSelection_BasicInfo_Level {
+            get {
+                return ResourceManager.GetString("ColumnSelection_BasicInfo_Level", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Logger.
+        /// </summary>
+        public static string ColumnSelection_BasicInfo_Logger {
+            get {
+                return ResourceManager.GetString("ColumnSelection_BasicInfo_Logger", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Message.
+        /// </summary>
+        public static string ColumnSelection_BasicInfo_Message {
+            get {
+                return ResourceManager.GetString("ColumnSelection_BasicInfo_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Thread.
+        /// </summary>
+        public static string ColumnSelection_BasicInfo_Thread {
+            get {
+                return ResourceManager.GetString("ColumnSelection_BasicInfo_Thread", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Timestamp.
+        /// </summary>
+        public static string ColumnSelection_BasicInfo_Timestamp {
+            get {
+                return ResourceManager.GetString("ColumnSelection_BasicInfo_Timestamp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Basic information.
+        /// </summary>
+        public static string ColumnSelection_BasicInfoGroup_Header {
+            get {
+                return ResourceManager.GetString("ColumnSelection_BasicInfoGroup_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cancel.
+        /// </summary>
+        public static string ColumnSelection_Button_Cancel {
+            get {
+                return ResourceManager.GetString("ColumnSelection_Button_Cancel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        public static string ColumnSelection_Button_OK {
+            get {
+                return ResourceManager.GetString("ColumnSelection_Button_OK", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select columns to appear in the Main window:.
+        /// </summary>
+        public static string ColumnSelection_Description {
+            get {
+                return ResourceManager.GetString("ColumnSelection_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Id.
+        /// </summary>
+        public static string ColumnSelection_Id {
+            get {
+                return ResourceManager.GetString("ColumnSelection_Id", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Class.
+        /// </summary>
+        public static string ColumnSelection_LocationInfo_Class {
+            get {
+                return ResourceManager.GetString("ColumnSelection_LocationInfo_Class", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Method.
+        /// </summary>
+        public static string ColumnSelection_LocationInfo_Method {
+            get {
+                return ResourceManager.GetString("ColumnSelection_LocationInfo_Method", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Location information.
+        /// </summary>
+        public static string ColumnSelection_LocationInfoGroup_Header {
+            get {
+                return ResourceManager.GetString("ColumnSelection_LocationInfoGroup_Header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to YALV!- Column Selection.
+        /// </summary>
+        public static string ColumnSelection_Title {
+            get {
+                return ResourceManager.GetString("ColumnSelection_Title", resourceCulture);
             }
         }
         
@@ -888,6 +1059,15 @@ namespace YALV.Properties {
         public static string MainWindow_FullDateTimeFormatWithMilliseconds {
             get {
                 return ResourceManager.GetString("MainWindow_FullDateTimeFormatWithMilliseconds", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Select columns....
+        /// </summary>
+        public static string MainWindow_GridColumnHeaderContextMenu_SelectColumns {
+            get {
+                return ResourceManager.GetString("MainWindow_GridColumnHeaderContextMenu_SelectColumns", resourceCulture);
             }
         }
         

--- a/src/YALV/Properties/Resources.Designer.cs
+++ b/src/YALV/Properties/Resources.Designer.cs
@@ -361,7 +361,7 @@ namespace YALV.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to YALV!- Column Selection.
+        ///   Looks up a localized string similar to YALV! - Column Selection.
         /// </summary>
         public static string ColumnSelection_Title {
             get {

--- a/src/YALV/Properties/Resources.resx
+++ b/src/YALV/Properties/Resources.resx
@@ -529,4 +529,64 @@ It is a WPF Application based on .NET Framework 4.0 and written with C# language
   <data name="MainWindow_FilesListBoxContextMenu_SelectNone_Header" xml:space="preserve">
     <value>Clear All Files</value>
   </data>
+  <data name="ColumnSelection_ApplicationInfoGroup_Header" xml:space="preserve">
+    <value>Application information</value>
+  </data>
+  <data name="ColumnSelection_ApplicationInfo_Application" xml:space="preserve">
+    <value>Application</value>
+  </data>
+  <data name="ColumnSelection_ApplicationInfo_HostName" xml:space="preserve">
+    <value>Host name</value>
+  </data>
+  <data name="ColumnSelection_ApplicationInfo_MachineName" xml:space="preserve">
+    <value>Machine name</value>
+  </data>
+  <data name="ColumnSelection_ApplicationInfo_UserName" xml:space="preserve">
+    <value>User name</value>
+  </data>
+  <data name="ColumnSelection_BasicInfoGroup_Header" xml:space="preserve">
+    <value>Basic information</value>
+  </data>
+  <data name="ColumnSelection_BasicInfo_Level" xml:space="preserve">
+    <value>Level</value>
+  </data>
+  <data name="ColumnSelection_BasicInfo_Logger" xml:space="preserve">
+    <value>Logger</value>
+  </data>
+  <data name="ColumnSelection_BasicInfo_Message" xml:space="preserve">
+    <value>Message</value>
+  </data>
+  <data name="ColumnSelection_BasicInfo_Thread" xml:space="preserve">
+    <value>Thread</value>
+  </data>
+  <data name="ColumnSelection_BasicInfo_Timestamp" xml:space="preserve">
+    <value>Timestamp</value>
+  </data>
+  <data name="ColumnSelection_LocationInfoGroup_Header" xml:space="preserve">
+    <value>Location information</value>
+  </data>
+  <data name="ColumnSelection_LocationInfo_Class" xml:space="preserve">
+    <value>Class</value>
+  </data>
+  <data name="ColumnSelection_LocationInfo_Method" xml:space="preserve">
+    <value>Method</value>
+  </data>
+  <data name="ColumnSelection_Description" xml:space="preserve">
+    <value>Select columns to appear in the Main window:</value>
+  </data>
+  <data name="ColumnSelection_Id" xml:space="preserve">
+    <value>Id</value>
+  </data>
+  <data name="ColumnSelection_Title" xml:space="preserve">
+    <value>YALV!- Column Selection</value>
+  </data>
+  <data name="ColumnSelection_Button_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="ColumnSelection_Button_OK" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="MainWindow_GridColumnHeaderContextMenu_SelectColumns" xml:space="preserve">
+    <value>Select columns...</value>
+  </data>
 </root>

--- a/src/YALV/Properties/Resources.resx
+++ b/src/YALV/Properties/Resources.resx
@@ -578,7 +578,7 @@ It is a WPF Application based on .NET Framework 4.0 and written with C# language
     <value>Id</value>
   </data>
   <data name="ColumnSelection_Title" xml:space="preserve">
-    <value>YALV!- Column Selection</value>
+    <value>YALV! - Column Selection</value>
   </data>
   <data name="ColumnSelection_Button_Cancel" xml:space="preserve">
     <value>Cancel</value>

--- a/src/YALV/SelectColumns.xaml
+++ b/src/YALV/SelectColumns.xaml
@@ -1,0 +1,110 @@
+﻿<Window x:Class="YALV.SelectColumns"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:properties="clr-namespace:YALV.Properties"
+        Title="{x:Static properties:Resources.ColumnSelection_Title}"
+        Height="310" Width="300" 
+        ResizeMode="NoResize" 
+        WindowStartupLocation="CenterOwner" 
+        WindowStyle="ToolWindow">
+    <StackPanel
+        Margin="10,0,10,0"
+        Orientation="Vertical">
+        <StackPanel.Resources>
+            <Style TargetType="{x:Type GroupBox}">
+                <Setter Property="Margin" Value="0,5,0,0"/>
+            </Style>
+            <Style TargetType="{x:Type CheckBox}">
+                <Setter Property="Margin" Value="5,5,0,0" />
+            </Style>
+        </StackPanel.Resources>
+        <TextBlock
+            Margin="5,5,0,0"
+            Text="{x:Static properties:Resources.ColumnSelection_Description}" />
+        <!-- Basic info -->
+        <GroupBox 
+            Header="{x:Static properties:Resources.ColumnSelection_BasicInfoGroup_Header}">
+            <UniformGrid Rows="3" Columns="2">
+                <CheckBox
+                    IsChecked ="{Binding Path=ShowId}">
+                    <TextBlock Text="{x:Static properties:Resources.ColumnSelection_Id}" />
+                </CheckBox>
+                <CheckBox
+                    IsChecked ="{Binding Path=ShowTimestamp}">
+                    <TextBlock Text="{x:Static properties:Resources.ColumnSelection_BasicInfo_Timestamp}"/>
+                </CheckBox>
+                <CheckBox
+                    IsChecked ="{Binding Path=ShowThread}">
+                    <TextBlock Text="{x:Static properties:Resources.ColumnSelection_BasicInfo_Thread}"/>
+                </CheckBox>
+                <CheckBox
+                    IsChecked ="{Binding Path=ShowLevel}">
+                    <TextBlock Text="{x:Static properties:Resources.ColumnSelection_BasicInfo_Level}"/>
+                </CheckBox>
+                <CheckBox
+                    IsChecked ="{Binding Path=ShowLogger}">
+                    <TextBlock Text="{x:Static properties:Resources.ColumnSelection_BasicInfo_Logger}"/>
+                </CheckBox>
+                <CheckBox
+                    IsChecked ="{Binding Path=ShowMessage}">
+                    <TextBlock Text="{x:Static properties:Resources.ColumnSelection_BasicInfo_Message}"/>
+                </CheckBox>
+            </UniformGrid>
+        </GroupBox>
+        <!-- Application info -->
+        <GroupBox 
+            Header="{x:Static properties:Resources.ColumnSelection_ApplicationInfoGroup_Header}">
+            <UniformGrid Rows="2" Columns="2">
+                <CheckBox
+                    IsChecked ="{Binding Path=ShowApplication}">
+                    <TextBlock Text="{x:Static properties:Resources.ColumnSelection_ApplicationInfo_Application}"/>
+                </CheckBox>
+                <CheckBox
+                    IsChecked ="{Binding Path=ShowUserName}">
+                    <TextBlock Text="{x:Static properties:Resources.ColumnSelection_ApplicationInfo_UserName}"/>
+                </CheckBox>
+                <CheckBox
+                    IsChecked ="{Binding Path=ShowMachineName}">
+                    <TextBlock Text="{x:Static properties:Resources.ColumnSelection_ApplicationInfo_MachineName}"/>
+                </CheckBox>
+                <CheckBox
+                    IsChecked ="{Binding Path=ShowHostName}">
+                    <TextBlock Text="{x:Static properties:Resources.ColumnSelection_ApplicationInfo_HostName}"/>
+                </CheckBox>
+            </UniformGrid>
+        </GroupBox>
+        <!-- Code info -->
+        <GroupBox 
+            Header="{x:Static properties:Resources.ColumnSelection_LocationInfoGroup_Header}">
+            <UniformGrid Rows="1" Columns="2">
+                <CheckBox
+                    IsChecked ="{Binding Path=ShowClass}">
+                    <TextBlock Text="{x:Static properties:Resources.ColumnSelection_LocationInfo_Class}"/>
+                </CheckBox>
+                <CheckBox
+                    IsChecked ="{Binding Path=ShowMethod}">
+                    <TextBlock Text="{x:Static properties:Resources.ColumnSelection_LocationInfo_Method}"/>
+                </CheckBox>
+            </UniformGrid>
+        </GroupBox>
+        <!-- Buttons -->
+        <StackPanel
+            Margin="0,10,0,10"
+            Orientation="Horizontal"
+            HorizontalAlignment="Right">
+            <Button
+                Content="{x:Static properties:Resources.ColumnSelection_Button_OK}"
+                IsDefault="True"
+                Width="80" Height="25"
+                Command="{Binding Path=CommandOk}">
+            </Button>
+            <Button
+                Content="{x:Static properties:Resources.ColumnSelection_Button_Cancel}"
+                IsCancel="True"
+                Width="80" Height="25"
+                Margin="10,0,0,0"
+                Command="{Binding Path=CommandCancel}">
+            </Button>
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/src/YALV/SelectColumns.xaml.cs
+++ b/src/YALV/SelectColumns.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System.Windows;
+using YALV.Common;
+using YALV.Common.Interfaces;
+using YALV.ViewModel;
+
+namespace YALV
+{
+    /// <summary>
+    /// Interaction logic for SelectColumns.xaml
+    /// </summary>
+    public partial class SelectColumns : Window, IWinSimple
+    {
+        public SelectColumns()
+        {
+            InitializeComponent();
+        }
+
+        public bool? ShowDialog(FilteredGridManager filteredGrid)
+        {
+            using (var vm = new SelectColumnsVM(this, filteredGrid))
+            {
+                this.DataContext = vm;
+                return this.ShowDialog();
+            }
+        }
+    }
+}

--- a/src/YALV/ViewModel/MainWindowVM.cs
+++ b/src/YALV/ViewModel/MainWindowVM.cs
@@ -36,6 +36,7 @@ namespace YALV.ViewModel
             CommandSelectAllFiles = new CommandRelay(commandSelectAllFilesExecute, commandSelectAllFilesCanExecute);
             CommandIncreaseInterval = new CommandRelay(commandIncreaseIntervalExecute, p => true);
             CommandDecreaseInterval = new CommandRelay(commandDecreaseIntervalExecute, p => true);
+            CommandSelectColumns = new CommandRelay(commandSelectColumnsExecute, _ => true);
             CommandAbout = new CommandRelay(commandAboutExecute, p => true);
 
             FileList = new ObservableCollection<FileItem>();
@@ -147,6 +148,11 @@ namespace YALV.ViewModel
         /// SelectAllFiles Command
         /// </summary>
         public ICommandAncestor CommandSelectAllFiles { get; protected set; }
+
+        /// <summary>
+        /// SelectColumns command
+        /// </summary>
+        public ICommandAncestor CommandSelectColumns { get; protected set; }
 
         /// <summary>
         /// About Command
@@ -452,6 +458,13 @@ namespace YALV.ViewModel
         {
             var win = new About() { Owner = _callingWin as Window };
             win.ShowDialog();
+            return null;
+        }
+
+        protected virtual object commandSelectColumnsExecute(object parameter)
+        {
+            var win = new SelectColumns() { Owner = _callingWin as Window };
+            win.ShowDialog(GridManager);
             return null;
         }
 
@@ -1388,6 +1401,7 @@ namespace YALV.ViewModel
                     {
                         item.columnItem.Width = item.columnRenderSettings.Width;
                         item.columnItem.DisplayIndex = item.columnRenderSettings.DisplayIndex;
+                        item.columnItem.Visible = item.columnRenderSettings.Visible;
                     }
 
                     dgColumns.Sort(new ColumnItemComparer());

--- a/src/YALV/ViewModel/SelectColumnsVM.cs
+++ b/src/YALV/ViewModel/SelectColumnsVM.cs
@@ -1,0 +1,212 @@
+﻿using YALV.Common;
+using YALV.Common.Interfaces;
+using YALV.Core.Domain;
+
+namespace YALV.ViewModel
+{
+    public class SelectColumnsVM : BindableObject
+    {
+        private readonly IWinSimple _callingWin;
+        private readonly FilteredGridManager _filteredGrid;
+        private readonly ColumnVisibilitySettings _settings;
+
+        public SelectColumnsVM(IWinSimple win, FilteredGridManager filteredGrid)
+        {
+            _callingWin = win;
+            _filteredGrid = filteredGrid;
+            _settings = filteredGrid.GetColumnVisibilitySettings();
+            CommandOk = new CommandRelay(SaveSettings, _ => true);
+            CommandCancel = new CommandRelay(Exit, _ => true);
+        }
+
+        #region Commands
+
+        public ICommandAncestor CommandOk { get; private set; }
+        private object SaveSettings(object parameter)
+        {
+            try
+            {
+                _filteredGrid.UpdateColumVisibilitySettings(Settings);
+            }
+            finally
+            {
+                _callingWin.Close();
+            }
+            return null;
+        }
+
+        public ICommandAncestor CommandCancel { get; private set; }
+        private object Exit(object parameter)
+        {
+            _callingWin.Close();
+            return null;
+        }
+
+        #endregion
+
+        #region Public properties
+
+        public ColumnVisibilitySettings Settings
+        {
+            get { return _settings; }
+        }
+
+        public bool ShowId
+        {
+            get { return Settings.ShowId; }
+            set
+            {
+                if (value != Settings.ShowId)
+                {
+                    Settings.ShowId = value;
+                    RaisePropertyChanged(nameof(ShowId));
+                }
+            }
+        }
+
+        public bool ShowTimestamp
+        {
+            get { return Settings.ShowTimeStamp; }
+            set
+            {
+                if (value != Settings.ShowTimeStamp)
+                {
+                    Settings.ShowTimeStamp = value;
+                    RaisePropertyChanged(nameof(ShowTimestamp));
+                }
+            }
+        }
+
+        public bool ShowThread
+        {
+            get { return Settings.ShowThread; }
+            set
+            {
+                if (value != Settings.ShowThread)
+                {
+                    Settings.ShowThread = value;
+                    RaisePropertyChanged(nameof(ShowThread));
+                }
+            }
+        }
+
+        public bool ShowLevel
+        {
+            get { return Settings.ShowLevel; }
+            set
+            {
+                if (value != Settings.ShowLevel)
+                {
+                    Settings.ShowLevel = value;
+                    RaisePropertyChanged(nameof(ShowLevel));
+                }
+            }
+        }
+
+        public bool ShowLogger
+        {
+            get { return Settings.ShowLogger; }
+            set
+            {
+                if (value != Settings.ShowLogger)
+                {
+                    Settings.ShowLogger = value;
+                    RaisePropertyChanged(nameof(ShowLogger));
+                }
+            }
+        }
+
+        public bool ShowMessage
+        {
+            get { return Settings.ShowMessage; }
+            set
+            {
+                if (value != Settings.ShowMessage)
+                {
+                    Settings.ShowMessage = value;
+                    RaisePropertyChanged(nameof(ShowMessage));
+                }
+            }
+        }
+
+        public bool ShowApplication
+        {
+            get { return Settings.ShowApp; }
+            set
+            {
+                if (value != Settings.ShowApp)
+                {
+                    Settings.ShowApp = value;
+                    RaisePropertyChanged(nameof(ShowApplication));
+                }
+            }
+        }
+
+        public bool ShowUserName
+        {
+            get { return Settings.ShowUserName; }
+            set
+            {
+                if (value != Settings.ShowUserName)
+                {
+                    Settings.ShowUserName = value;
+                    RaisePropertyChanged(nameof(ShowUserName));
+                }
+            }
+        }
+
+        public bool ShowMachineName
+        {
+            get { return Settings.ShowMachineName; }
+            set
+            {
+                if (value != Settings.ShowMachineName)
+                {
+                    Settings.ShowMachineName = value;
+                    RaisePropertyChanged(nameof(ShowMachineName));
+                }
+            }
+        }
+
+        public bool ShowHostName
+        {
+            get { return Settings.ShowHostName; }
+            set
+            {
+                if (value != Settings.ShowHostName)
+                {
+                    Settings.ShowHostName = value;
+                    RaisePropertyChanged(nameof(ShowHostName));
+                }
+            }
+        }
+
+        public bool ShowClass
+        {
+            get { return Settings.ShowClass; }
+            set
+            {
+                if (value != Settings.ShowClass)
+                {
+                    Settings.ShowClass = value;
+                    RaisePropertyChanged(nameof(ShowClass));
+                }
+            }
+        }
+
+        public bool ShowMethod
+        {
+            get { return Settings.ShowMethod; }
+            set
+            {
+                if (value != Settings.ShowMethod)
+                {
+                    Settings.ShowMethod = value;
+                    RaisePropertyChanged(nameof(ShowMethod));
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/YALV/YALV.csproj
+++ b/src/YALV/YALV.csproj
@@ -105,6 +105,9 @@
     <Compile Include="AddFolderPath.xaml.cs">
       <DependentUpon>AddFolderPath.xaml</DependentUpon>
     </Compile>
+    <Compile Include="SelectColumns.xaml.cs">
+      <DependentUpon>SelectColumns.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Common\Components\BusyIndicatorBehavior\BusyIndicatorBehavior.cs" />
     <Compile Include="Common\Components\BusyIndicatorBehavior\CircularProgressBar.xaml.cs">
       <DependentUpon>CircularProgressBar.xaml</DependentUpon>
@@ -120,6 +123,7 @@
     <Compile Include="Common\Components\MainMenu.xaml.cs">
       <DependentUpon>MainMenu.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Common\CommandReference.cs" />
     <Compile Include="Common\Converters\AdjustValueConverter.cs" />
     <Compile Include="Common\Converters\BoolToOppositeVisibilityConverter.cs" />
     <Compile Include="Common\Converters\BoolToVisibilityConverter.cs" />
@@ -132,6 +136,7 @@
     <Compile Include="Common\GlobalHelper.cs" />
     <Compile Include="Common\Interfaces\ICommandAncestor.cs" />
     <Compile Include="Common\Interfaces\IWinSimple.cs" />
+    <Compile Include="ViewModel\SelectColumnsVM.cs" />
     <Compile Include="Common\RecentFileList.cs" />
     <Compile Include="Common\ScrollSynchronizer.cs" />
     <Compile Include="Common\Components\MainToolbar.xaml.cs">
@@ -159,6 +164,10 @@
     </Compile>
     <Compile Include="ViewModel\MainWindowVM.cs" />
     <Compile Include="ViewModel\AddFolderPathVM.cs" />
+    <Page Include="SelectColumns.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>


### PR DESCRIPTION
Hello.

I have been using YALV for the last 2 or 3 years and decided to contribute to this great work.

In this PR I added support to configure the settings of data grid columns so that:

- column order is preserved on next run. I added a new settings file called YALVSettings.xml in which the column settings such as order and size are persisted when the application shuts down.
- user can manage columns. I added a context menu on the data grid's header which opens a dialog that can be used to hide/show columns. Column visibility is also preserved on the next run.

Please let me know if you are OK with these changes. I have several other features that I'd like to share.

Thanks!