### PR TITLE
Added support to Json Log Format (Serilog.Formatter.JsonFormatter)

### DIFF
--- a/src/YALV.Core/DataService.cs
+++ b/src/YALV.Core/DataService.cs
@@ -97,7 +97,17 @@ namespace YALV.Core
             IEnumerable<LogItem> result = null;
             try
             {
-                AbstractEntriesProvider provider = EntriesProviderFactory.GetProvider();
+                AbstractEntriesProvider provider;
+
+                if (Path.GetExtension(path) == ".json")
+                { 
+                    provider = EntriesProviderFactory.GetProvider(EntriesProviderType.Json);
+                }
+                else
+                {
+                    provider = EntriesProviderFactory.GetProvider();
+                }
+
                 result = provider.GetEntries(path);
                 return result.ToList();
             }

--- a/src/YALV.Core/Domain/EntriesProviderType.cs
+++ b/src/YALV.Core/Domain/EntriesProviderType.cs
@@ -1,4 +1,4 @@
 namespace YALV.Core.Domain
 {
-    public enum EntriesProviderType { Xml, Sqlite, MsSqlServer }
+    public enum EntriesProviderType { Xml, Sqlite, MsSqlServer, Json }
 }

--- a/src/YALV.Core/Providers/EntriesProviderFactory.cs
+++ b/src/YALV.Core/Providers/EntriesProviderFactory.cs
@@ -17,7 +17,9 @@ namespace YALV.Core.Providers
 
                 case EntriesProviderType.MsSqlServer:
                     return new MsSqlServerEntriesProvider();
-
+					
+                case EntriesProviderType.Json:
+                    return new JsonEntriesProvider();
                 default:
                     var message = String.Format((string) "Type {0} not supported", (object) type);
                     throw new NotImplementedException(message);

--- a/src/YALV.Core/Providers/JsonEntriesProvider.cs
+++ b/src/YALV.Core/Providers/JsonEntriesProvider.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+using YALV.Core.Domain;
+
+namespace YALV.Core.Providers
+{
+    class JsonEntriesProvider : AbstractEntriesProvider
+    {
+        public override IEnumerable<LogItem> GetEntries(string dataSource, FilterParams filter)
+        {
+            var entryId = 1;
+
+            FileStream fs = new FileStream(dataSource, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.ReadWrite);
+            StreamReader sr = new StreamReader(fs);
+
+            while (!sr.EndOfStream)
+            {
+                var line = sr.ReadLine();
+                var lineObject = JsonConvert.DeserializeObject<JObject>(line);
+
+                LogItem entry = new LogItem()
+                {
+                    File = dataSource,
+                    Message = lineObject.SelectToken("MessageTemplate")?.Value<String>() ?? "",
+                    TimeStamp = lineObject.SelectToken("Timestamp").Value<DateTime>(),
+                    Level = lineObject.SelectToken("Level")?.Value<String>().ToUpper() ?? "",
+                    App = lineObject.SelectToken("Properties").SelectToken("ProcessName")?.Value<String>() ?? "",
+                    Thread = lineObject.SelectToken("Properties").SelectToken("ThreadId")?.Value<String>() ?? "",
+                    MachineName = lineObject.SelectToken("Properties").SelectToken("MachineName")?.Value<String>() ?? "",
+                    UserName = lineObject.SelectToken("Properties").SelectToken("EnvironmentUserName")?.Value<String>() ?? "",
+                    Id = entryId,
+                    Path = dataSource
+                };
+
+                // adjust LEVEL:
+                if (entry.Level == "INFORMATION")
+                    entry.Level = "INFO";
+                else if (entry.Level == "WARNING")
+                    entry.Level = "WARN";
+
+
+                // replace properties into message template
+                foreach(JProperty property in lineObject.SelectToken("Properties").Children())
+                {
+                    string token = "{" + property.Name + "}";
+                    string value = property.Value.Value<string>();
+
+                    entry.Message = entry.Message.Replace(token, value);
+                }
+
+                if (filterByParameters(entry, filter))
+                {
+                    yield return entry;
+                    entryId++;
+                }
+            }
+        }
+
+        private static bool filterByParameters(LogItem entry, FilterParams parameters)
+        {
+            if (entry == null)
+                throw new ArgumentNullException("entry");
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            bool accept = false;
+            switch (parameters.Level)
+            {
+                case 1:
+                    if (String.Equals(entry.Level, "ERROR",
+                        StringComparison.InvariantCultureIgnoreCase))
+                        accept = true;
+                    break;
+
+                case 2:
+                    if (String.Equals(entry.Level, "INFO",
+                        StringComparison.InvariantCultureIgnoreCase))
+                        accept = true;
+                    break;
+
+                case 3:
+                    if (String.Equals(entry.Level, "DEBUG",
+                        StringComparison.InvariantCultureIgnoreCase))
+                        accept = true;
+                    break;
+
+                case 4:
+                    if (String.Equals(entry.Level, "WARN",
+                        StringComparison.InvariantCultureIgnoreCase))
+                        accept = true;
+                    break;
+
+                case 5:
+                    if (String.Equals(entry.Level, "FATAL",
+                        StringComparison.InvariantCultureIgnoreCase))
+                        accept = true;
+                    break;
+
+                default:
+                    accept = true;
+                    break;
+            }
+
+            if (parameters.Date.HasValue)
+                if (entry.TimeStamp < parameters.Date)
+                    accept = false;
+
+            if (!String.IsNullOrEmpty(parameters.Thread))
+                if (!String.Equals(entry.Thread, parameters.Thread, StringComparison.InvariantCultureIgnoreCase))
+                    accept = false;
+
+            if (!String.IsNullOrEmpty(parameters.Message))
+                if (!entry.Message.ToUpper().Contains(parameters.Message.ToUpper()))
+                    accept = false;
+
+            if (!String.IsNullOrEmpty(parameters.Logger))
+                if (!entry.Logger.ToUpper().Contains(parameters.Logger.ToUpper()))
+                    accept = false;
+
+            return accept;
+        }
+    }
+}

--- a/src/YALV.Core/YALV.Core.csproj
+++ b/src/YALV.Core/YALV.Core.csproj
@@ -31,6 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.SQLite">
@@ -60,7 +63,11 @@
     <Compile Include="Providers\FileEntriesProvider.cs" />
     <Compile Include="Providers\MsSqlServerEntriesProvider.cs" />
     <Compile Include="Providers\SqliteEntriesProvider.cs" />
+    <Compile Include="Providers\JsonEntriesProvider.cs" />
     <Compile Include="Providers\XmlEntriesProvider.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/YALV.Core/packages.config
+++ b/src/YALV.Core/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net40-client" />
+</packages>

--- a/src/YALV/Properties/Resources.Designer.cs
+++ b/src/YALV/Properties/Resources.Designer.cs
@@ -1029,6 +1029,15 @@ namespace YALV.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Json files.
+        /// </summary>
+        public static string MainWindowVM_commandOpenFileExecute_JsonFilesCaption {
+            get {
+                return ResourceManager.GetString("MainWindowVM_commandOpenFileExecute_JsonFilesCaption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Open Log File.
         /// </summary>
         public static string MainWindowVM_commandOpenFileExecute_Open_Log_File {

--- a/src/YALV/Properties/Resources.de.resx
+++ b/src/YALV/Properties/Resources.de.resx
@@ -529,4 +529,7 @@ Diese Anwendung basiert auf das .NET Framework 4.0 mit WPF unter Verwendung ver 
   <data name="MainWindow_FilesListBoxContextMenu_SelectNone_Header" xml:space="preserve">
     <value>Alles Löschen</value>
   </data>
+  <data name="MainWindowVM_commandOpenFileExecute_JsonFilesCaption" xml:space="preserve">
+    <value>Json-Dateien</value>
+  </data>
 </root>

--- a/src/YALV/Properties/Resources.el.resx
+++ b/src/YALV/Properties/Resources.el.resx
@@ -529,4 +529,7 @@
   <data name="MainWindow_FilesListBoxContextMenu_SelectNone_Header" xml:space="preserve">
     <value>Τα καθαρίζω όλα</value>
   </data>
+  <data name="MainWindowVM_commandOpenFileExecute_JsonFilesCaption" xml:space="preserve">
+    <value>Αρχεία Json</value>
+  </data>
 </root>

--- a/src/YALV/Properties/Resources.fr.resx
+++ b/src/YALV/Properties/Resources.fr.resx
@@ -529,4 +529,7 @@ C'est le logiciel WPF fondé sur .NET Framework 4.0 et écrite en C#.</value>
   <data name="MainWindow_FilesListBoxContextMenu_SelectNone_Header" xml:space="preserve">
     <value>Tout effacer</value>
   </data>
+  <data name="MainWindowVM_commandOpenFileExecute_JsonFilesCaption" xml:space="preserve">
+    <value>Les fichiers Json</value>
+  </data>
 </root>

--- a/src/YALV/Properties/Resources.it.resx
+++ b/src/YALV/Properties/Resources.it.resx
@@ -529,4 +529,7 @@ Si tratta di un'applicazione WPF basata sul .NET Framework 4.0 e scritta con il 
   <data name="MainWindow_FilesListBoxContextMenu_SelectNone_Header" xml:space="preserve">
     <value>Deseleziona Tutti I Files</value>
   </data>
+  <data name="MainWindowVM_commandOpenFileExecute_JsonFilesCaption" xml:space="preserve">
+    <value>Json files</value>
+  </data>
 </root>

--- a/src/YALV/Properties/Resources.ja.resx
+++ b/src/YALV/Properties/Resources.ja.resx
@@ -522,4 +522,7 @@ Log4Net の設定ファイルは "XmlLayoutSchemaLog4j" レイアウトである
   <data name="MainWindow_FilesListBoxContextMenu_SelectNone_Header" xml:space="preserve">
     <value>すべてクリア</value>
   </data>
+  <data name="MainWindowVM_commandOpenFileExecute_JsonFilesCaption" xml:space="preserve">
+    <value>Json ファイル</value>
+  </data>
 </root>

--- a/src/YALV/Properties/Resources.resx
+++ b/src/YALV/Properties/Resources.resx
@@ -529,4 +529,7 @@ It is a WPF Application based on .NET Framework 4.0 and written with C# language
   <data name="MainWindow_FilesListBoxContextMenu_SelectNone_Header" xml:space="preserve">
     <value>Clear All Files</value>
   </data>
+  <data name="MainWindowVM_commandOpenFileExecute_JsonFilesCaption" xml:space="preserve">
+    <value>Json files</value>
+  </data>
 </root>

--- a/src/YALV/Properties/Resources.ru.resx
+++ b/src/YALV/Properties/Resources.ru.resx
@@ -529,4 +529,7 @@ Log4Net должен быть сконфигурирован с шаблоном
   <data name="MainWindow_FilesListBoxContextMenu_SelectNone_Header" xml:space="preserve">
     <value>Очистить все</value>
   </data>
+  <data name="MainWindowVM_commandOpenFileExecute_JsonFilesCaption" xml:space="preserve">
+    <value>Файлы Json</value>
+  </data>
 </root>

--- a/src/YALV/Properties/Resources.zh-CN.resx
+++ b/src/YALV/Properties/Resources.zh-CN.resx
@@ -529,4 +529,7 @@ Log4Net 配置必须设为 XmlLayoutSchemaLog4j 布局；在您的应用程序�
   <data name="MainWindow_FilesListBoxContextMenu_SelectNone_Header" xml:space="preserve">
     <value>全部清除</value>
   </data>
+  <data name="MainWindowVM_commandOpenFileExecute_JsonFilesCaption" xml:space="preserve">
+    <value>Json 文件</value>
+  </data>
 </root>

--- a/src/YALV/ViewModel/MainWindowVM.cs
+++ b/src/YALV/ViewModel/MainWindowVM.cs
@@ -164,7 +164,7 @@ namespace YALV.ViewModel
             using (System.Windows.Forms.OpenFileDialog dlg = new System.Windows.Forms.OpenFileDialog())
             {
                 bool addFile = parameter != null && parameter.Equals("ADD");
-                dlg.Filter = String.Format("{0} (*.xml)|*.xml|{1} (*.*)|*.*", Properties.Resources.MainWindowVM_commandOpenFileExecute_XmlFilesCaption, Properties.Resources.MainWindowVM_commandOpenFileExecute_AllFilesCaption);
+                dlg.Filter = String.Format("{0} (*.xml)|*.xml|{1} (*.json)|*.json|{2} (*.*)|*.*", Properties.Resources.MainWindowVM_commandOpenFileExecute_XmlFilesCaption, Properties.Resources.MainWindowVM_commandOpenFileExecute_JsonFilesCaption, Properties.Resources.MainWindowVM_commandOpenFileExecute_AllFilesCaption);
                 dlg.DefaultExt = "xml";
                 dlg.Multiselect = true;
                 dlg.Title = addFile ? Resources.MainWindowVM_commandOpenFileExecute_Add_Log_File : Resources.MainWindowVM_commandOpenFileExecute_Open_Log_File;


### PR DESCRIPTION
Serilog default log format is Json instead of XML. So I think it is a good idea to have support to this into YALV.

There still probably some additional step to full support (I was not able to check every option available into the log, but all the basic is already working).